### PR TITLE
Add /port endpoint to echo the incoming port

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -16,6 +16,7 @@ func New(logger lager.Logger) rata.Handlers {
 		routes.Hello: &Hello{Time: t},
 		routes.Exit:  &Exit{Time: t},
 		routes.Index: &Index{},
+		routes.Port: &Port{},
 	}
 
 	for route, handler := range handlers {

--- a/handlers/port.go
+++ b/handlers/port.go
@@ -1,0 +1,16 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type Port struct {
+}
+
+func (_ *Port) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	port := strings.Split(r.Host,":")[1]
+
+	w.Write([]byte(fmt.Sprintf("%s", port)))
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -7,6 +7,7 @@ const (
 	Hello = "HELLO"
 	Exit  = "EXIT"
 	Index = "INDEX"
+	Port  = "PORT"
 )
 
 var Routes = rata.Routes{
@@ -14,4 +15,5 @@ var Routes = rata.Routes{
 	{Path: "/env", Method: "GET", Name: Env},
 	{Path: "/exit", Method: "GET", Name: Exit},
 	{Path: "/index", Method: "GET", Name: Index},
+	{Path: "/port", Method: "GET", Name: Port},
 }


### PR DESCRIPTION
This is useful for testing TCP/HTTP port routing, to verify that the
correct incoming port is being used.

[#107248522]
